### PR TITLE
Fix "Click to draw" for first object

### DIFF
--- a/vectordraw.js
+++ b/vectordraw.js
@@ -458,7 +458,7 @@ VectorDraw.prototype.onBoardDown = function(evt) {
     var selected = this.getSelectedElement();
     var coords = this.getMouseCoords(evt);
     var targetObjects = this.objectsUnderMouse(coords);
-    if (selected.idx && _.all(targetObjects, this.canCreateVectorOnTopOf.bind(this)) ) {
+    if ( typeof(selected.idx) !== undefined && _.all(targetObjects, this.canCreateVectorOnTopOf.bind(this)) ) {
         var point_coords = [coords.usrCoords[1], coords.usrCoords[2]];
         if (selected.type === 'vector') {
             this.drawMode = true;

--- a/vectordraw.js
+++ b/vectordraw.js
@@ -458,7 +458,7 @@ VectorDraw.prototype.onBoardDown = function(evt) {
     var selected = this.getSelectedElement();
     var coords = this.getMouseCoords(evt);
     var targetObjects = this.objectsUnderMouse(coords);
-    if (selected.idx && (!targetObjects || _.all(targetObjects, this.canCreateVectorOnTopOf.bind(this)))) {
+    if (selected.idx && _.all(targetObjects, this.canCreateVectorOnTopOf.bind(this)) ) {
         var point_coords = [coords.usrCoords[1], coords.usrCoords[2]];
         if (selected.type === 'vector') {
             this.drawMode = true;


### PR DESCRIPTION
In recent versions of `vectordraw.js`, clicking on the board would not draw the first object, but would draw for subsequent objects.

This seems to have been caused by an `if(selected.idx ...` introduced at 8f68171. I believe this portion of the `if` statement is intended to check that `selected.idx` exists, but fails for the first object whose `idx` value is `0`. 

See [live example](https://edge.edx.org/courses/course-v1:CAC+CAC101+FOREVER/courseware/054cdf7bdc174cc9a34265988104e657/d1a9e474f6c94473af47d3a989aaf00d/1?activate_block_id=block-v1%3ACAC%2BCAC101%2BFOREVER%2Btype%40vertical%2Bblock%40bc66394cc45c470e854ce96e409202ac).

(Earlier versions of `vectordraw.js` escaped this bug because `vec_idx = this.element.find('.menu select').val();` was used in the conditional instead and this assignment coerced `idx` to a string). 

---

Also: I deleted the `!targetObjects` part of the conditional. I am pretty sure `targetObjects` always returns a list, in which case `!targetObjects` is always false. (Even `![]` is false).
