### PR TITLE
Remove tail point from arrows

### DIFF
--- a/api-example.html
+++ b/api-example.html
@@ -32,7 +32,12 @@
                         name: 'f', description: 'Friction - f', coords: [[-2, -5], [-1, -3]], render: false,
                         style: {pointSize:3, pointColor: 'green', label: "Fric", color:"#cccccc", width:1.5}
                     },
-                    {name: 'g', description: 'Gravity - g', tail: [0, 1.5], length: 5, angle: -75, render: false}
+                    {
+                        name: 'g', description: 'Gravity - g', tail: [0, 1.5], length: 5, angle: -75, render: false
+                    },
+                    {
+                        name: 'Line', description: 'Demo Line', type: 'line', render: false
+                    }
               ],
               points: [{name: 'cm', coords: [0, -0.75]}],
               expected_result: {

--- a/api-example.html
+++ b/api-example.html
@@ -37,6 +37,9 @@
                     },
                     {
                         name: 'Line', description: 'Demo Line', type: 'line', render: false
+                    },
+                    {
+                        name: 'Segment', description: 'Demo Segment', type: 'line', render: false
                     }
               ],
               points: [{name: 'cm', coords: [0, -0.75]}],

--- a/api-example.html
+++ b/api-example.html
@@ -39,7 +39,7 @@
                         name: 'Line', description: 'Demo Line', type: 'line', render: false
                     },
                     {
-                        name: 'Segment', description: 'Demo Segment', type: 'line', render: false
+                        name: 'Segment', description: 'Demo Segment', type: 'segment', render: false
                     }
               ],
               points: [{name: 'cm', coords: [0, -0.75]}],

--- a/vectordraw.js
+++ b/vectordraw.js
@@ -263,7 +263,7 @@ VectorDraw.prototype.renderVector = function(idx, coords) {
 
     var tail = this.board.create('point', coords[0], {
         name: vec.name,
-        size: style.pointSize,
+        size: (vec.type === 'arrow' | vec.type === 'vector') ? -1 : style.pointSize,
         fillColor: style.pointColor,
         strokeColor: style.pointColor,
         withLabel: false,


### PR DESCRIPTION
Previously, all vector objects (arrows, segments, and lines) were drawn with a tail point and a tip point. For arrows, however, the tail point is not draggable and serves no purpose.

This PR hides the tail point for arrows.

![comparison](https://cloud.githubusercontent.com/assets/9010790/17305359/106fec42-57f8-11e6-9d63-58e15b330692.png)
