### PR TITLE
Snapping vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ supports these properties:
 * `custom_checks`: An array of custom checks used for grading. This is
   needed when the grading is more complex and can't be defined in
   terms of `expected_result` only. More info below.
+* `snap_angle_increment`: degree increment at which to snap angles for vectors, segments, and lines. (Defaults to `0`, no snapping.)
 * `axis`: Show the graph axis (defaults to `false`).
 * `show_navigation`: Show navigation arrows and zooom controls
   (defaults to `false`).

--- a/api-example.html
+++ b/api-example.html
@@ -44,7 +44,10 @@
               ],
               points: [
                   {name: 'cm', coords: [0, -0.75]},
-                  {name: 'Point', description:"Demo Point", coords: [0, 1], fixed:false}
+                  {
+                    name: 'Point', fixed: false, description: 'Demo Point',
+                    render: false, style: {color: '#ff00ff', size: 2}
+                  }
               ],
               expected_result: {
                  'N': {angle: 90, angle_tolerance: 2, tail: [0, -0.75], tail_tolerance: 0.25},

--- a/api-example.html
+++ b/api-example.html
@@ -42,7 +42,10 @@
                         name: 'Segment', description: 'Demo Segment', type: 'segment', render: false
                     }
               ],
-              points: [{name: 'cm', coords: [0, -0.75]}],
+              points: [
+                  {name: 'cm', coords: [0, -0.75]},
+                  {name: 'Point', description:"Demo Point", coords: [0, 1], fixed:false}
+              ],
               expected_result: {
                  'N': {angle: 90, angle_tolerance: 2, tail: [0, -0.75], tail_tolerance: 0.25},
                  'g': {angle: 270, angle_errmsg: 'Gravity angle is wrong.', angle_tolerance: 2, tail: [0, -0.75], tail_tolerance: 0.25},

--- a/api-example.html
+++ b/api-example.html
@@ -19,6 +19,7 @@
               width: 550,
               height: 450,
               bounding_box_size: 8,
+              snap_angle_increment:10,
               background: {
                   src: 'simple_car.png',
                   width: 20


### PR DESCRIPTION
Adds an optional global setting `snap_angle_increment` that causes vectors to be snapped to nice angle increments when the user ends dragging. During the snap, the magnitude is unchanged and exactly one of the `tip`, `tail` will be moved (whichever one the user has been dragging).

Examples:
- `snap_angle_increment:0` no snapping. (Default, for backward compatibility).
- `snap_angle_increment:10` snaps every 10 degrees (`0, 10, 20, ..., 350`) during `onBoardUp`.

Snapping only affects vectors, not points. 
