### PR TITLE
Fixed length vectors

### DIFF
--- a/api-example.html
+++ b/api-example.html
@@ -26,7 +26,7 @@
               },
               vectors: [
                     {
-                        name: 'N', description: 'Normal force - N', coords: [[2, 2], [4, 5]], render: true, fixed_length:true,
+                        name: 'N', description: 'Normal force - N', coords: [[2, 2], [4, 5]], render: true, fixed_length_and_orientation: true,
                         style: {pointSize:2, label: "Norm", color:"red", width:2}
                     },
                     {

--- a/api-example.html
+++ b/api-example.html
@@ -26,7 +26,7 @@
               },
               vectors: [
                     {
-                        name: 'N', description: 'Normal force - N', coords: [[2, 2], [7, 8]], render: true,
+                        name: 'N', description: 'Normal force - N', coords: [[2, 2], [4, 5]], render: true, fixed_length:true,
                         style: {pointSize:2, label: "Norm", color:"red", width:2}
                     },
                     {

--- a/vectordraw.js
+++ b/vectordraw.js
@@ -50,7 +50,7 @@ VectorDraw.prototype.sanitizeSettings = function(settings) {
         length_factor: 1,
         length_units: '',
         base_angle: 0,
-        fixed_length: false
+        fixed_length_and_orientation: false
     };
     var default_vector_style = {
         pointSize: 1,
@@ -284,7 +284,7 @@ VectorDraw.prototype.renderVector = function(idx, coords) {
         withLabel: false,
         showInfoBox: false
     });
-    if (vec.fixed_length){
+    if (vec.fixed_length_and_orientation){
         tip.hideElement();
     }
     var labelPoint  = this.board.create('point', [function(){return tip.X()}, function(){return tip.Y()}], {

--- a/vectordraw.js
+++ b/vectordraw.js
@@ -49,7 +49,8 @@ VectorDraw.prototype.sanitizeSettings = function(settings) {
         render: false,
         length_factor: 1,
         length_units: '',
-        base_angle: 0
+        base_angle: 0,
+        fixed_length: false
     };
     var default_vector_style = {
         pointSize: 1,
@@ -276,16 +277,25 @@ VectorDraw.prototype.renderVector = function(idx, coords) {
         showInfoBox: false
     });
     var tip = this.board.create('point', coords[1], {
-        name: style.label || vec.name,
+        name: vec.name,
         size: style.pointSize,
         fillColor: style.pointColor,
         strokeColor: style.pointColor,
-        withLabel: true,
+        withLabel: false,
         showInfoBox: false
     });
+    if (vec.fixed_length){
+        tip.hideElement();
+    }
+    var labelPoint  = this.board.create('point', [function(){return tip.X()}, function(){return tip.Y()}], {
+        name: style.label || vec.name,
+        withLabel: true,
+        size:-1,
+        showInfoBox: false
+    })
     // Not sure why, but including labelColor in attributes above doesn't work,
     // it only works when set explicitly with setAttribute.
-    tip.setAttribute({labelColor: style.labelColor});
+    labelPoint.setAttribute({labelColor: style.labelColor});
 
     var line_type = (vec.type === 'vector') ? 'arrow' : vec.type;
     var line = this.board.create(line_type, [tail, tip], {
@@ -294,7 +304,7 @@ VectorDraw.prototype.renderVector = function(idx, coords) {
         strokeColor: style.color
     });
 
-    tip.label.setAttribute({fontsize: 18, highlightStrokeColor: 'black'});
+    labelPoint.label.setAttribute({fontsize: 18, highlightStrokeColor: 'black'});
 
     // Disable the <option> element corresponding to vector.
     var option = this.getMenuOption('vector', idx);


### PR DESCRIPTION
This PR adds an optional setting for vectors, `fixed_length_and_orientation` which defaults to `false`. This settings makes the vector have ... fixed length and orientation. Great for "pre-drawing" vectors on a board.

Of course, the pre-drawn vectors could just be included as part of a background image. But using vectordraw with `render=true` and `fixed_length_and_orientation=true` has two chief advantages:
1. Allows students to drag the vectors, which is needed for solving many problems. E.g., vector addition.
2. Opens the door to randomization. 

Two use cases:
- pre-draw force vectors F1, F2, F3 and have students drawn total force F_total = F1 + F2 + F3
- pre-draw vectors A and B, have students draw parallel and perpendicular projections of A onto B.
